### PR TITLE
Use "view.match_selector()" rather than "in view.scope_name()"

### DIFF
--- a/autofilename.py
+++ b/autofilename.py
@@ -315,10 +315,10 @@ class FileNameComplete(sublime_plugin.EventListener):
         # print( "on_query_completions, blacklist: " + str( blacklist ) )
         # print( "on_query_completions, valid_scopes: " + str( valid_scopes ) )
 
-        if not any(scope in view.scope_name(selection) for scope in valid_scopes):
+        if not any(view.match_selector(selection, scope) for scope in valid_scopes):
             return
 
-        if blacklist and any(scope in view.scope_name(selection) for scope in blacklist):
+        if any(view.match_selector(selection, scope) for scope in blacklist):
             return
 
         self.view = view


### PR DESCRIPTION
The "in" operator is a simple string search while "match_selector()" is a decent ST's scope matching API.

```
match_selector(point, selector)
bool 
Checks the selector against the scope at the given point, returning a bool if they match.
```

https://www.sublimetext.com/docs/3/api_reference.html

---

With this patch, I can set something like
```js
	"afn_blacklist_scopes":
	[
		"string.regexp"
	],
	"afn_valid_scopes":
	[
		"text -text.html.basic", // I have VSCode's HTML LSP for path auto-completion and it cannot be disabled...
		"source string"
	],
```